### PR TITLE
fix randomSeed() argument type to match declaration

### DIFF
--- a/src/cores/arduino/WMath.cpp
+++ b/src/cores/arduino/WMath.cpp
@@ -21,7 +21,7 @@ extern "C" {
   #include "stdint.h"
 }
 
-extern void randomSeed( uint32_t dwSeed )
+extern void randomSeed( unsigned long dwSeed )
 {
   if ( dwSeed != 0 )
   {


### PR DESCRIPTION
fixes linker error being unable to find proper randomSeed() implementation